### PR TITLE
Modify accessor functions

### DIFF
--- a/pact/hft.pact
+++ b/pact/hft.pact
@@ -373,9 +373,13 @@
   (defun get-manifest:object{manifest} (id:string)
     (at 'manifest (read tokens id)))
 
-  (defun get-tokens:[string] ()
+  (defun get-token-keys:[string] ()
     "Get all token identifiers"
     (keys tokens))
+
+  (defun get-tokens:[object{token-schema}] ()
+    "Get all tokens"
+     (map (read tokens) (get-token-keys)))
 
   (defun get-token:object{token-schema} (id:string)
     "Read token"

--- a/pact/hft.pact
+++ b/pact/hft.pact
@@ -379,7 +379,7 @@
 
   (defun get-tokens:[object{token-schema}] ()
     "Get all tokens"
-     (map (read tokens) (get-token-keys)))
+     (map (read tokens) (keys tokens)))
 
   (defun get-token:object{token-schema} (id:string)
     "Read token"

--- a/pact/hft.repl
+++ b/pact/hft.repl
@@ -314,8 +314,17 @@
   (get-manifest 'project-0))
 
 (expect "Returns tokens"
-  ['project-0]
+   [{"id": "project-0"
+    ,"manifest": {"data": []
+    ,"hash": "E0pcFalaFSk5AJwR7QwpLbhzymaC8DCOSrCeBiDkpnY"
+    ,"uri": {"data": "project-0-uri","scheme": "text"}}
+    ,"policy": hft.guard-token-policy,"precision": 12
+    ,"supply": 5.0}]
   (get-tokens))
+
+(expect "Returns token keys"
+   ["project-0"]
+  (get-token-keys))
 
 (expect "Returns project-0 token"
   { 'id: "project-0"


### PR DESCRIPTION
- Rename `get-tokens` to `get-token-keys` 
- Modify `get-tokens` to return list of token schemas